### PR TITLE
Ajustar links da migração do 7.0 -> 7.1

### DIFF
--- a/appendices/migration71.xml
+++ b/appendices/migration71.xml
@@ -16,8 +16,8 @@
  <sect1 phd:chunk="false" xml:id="migration71.intro">
   <para>
    Esta nova versão menor traz vários
-   <link linkend="migration74.new-features">novos recursos</link> e
-   <link linkend="migration74.incompatible">algumas incompatibilidades</link>
+   <link linkend="migration71.new-features">novos recursos</link> e
+   <link linkend="migration71.incompatible">algumas incompatibilidades</link>
    que devem ser testadas antes da troca de versões do PHP em
    ambientes de produção.
   </para>


### PR DESCRIPTION
Olá, segue pequena correção nos links de documentação do PHP 7.0 -> 7.1